### PR TITLE
Added compose.yml, adds a config for the server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Oauth2-Mock-Server-Example
 Example of getting auth tokens from the OAuth2 Mock server
 
-We will use [https://github.com/navikt/mock-oauth2-server](Navikt's Mock Oauth2 Server) to back this example.
+We will use [Navikt's Mock Oauth2](https://github.com/navikt/mock-oauth2-server) Server to back this example.
 In particular, this guide will walk you through:
 
 1)  Starting up the Docker OAuth2 server with appropriate settings.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ docker pull ghcr.io/navikt/mock-oauth2-server:2.1.10
 
 You can now run the server with:
 ```bash
-docker run -p 8080:8080 ghcr.io/navikt/mock-oauth2-server:2.1.10
+docker compose up
 ```
 
 Note that, if the server is running in this way, we can get a login page by sending, e.g., a request to [this url](http://localhost:8080/default/authorize?client_id=foo&response_type=code&redirect_uri=http://localhost:3000&scope=openid).

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ docker pull ghcr.io/navikt/mock-oauth2-server:2.1.10
 
 You can now run the server with:
 ```bash
-docker compose up
+docker-compose up
 ```
 
 Note that, if the server is running in this way, we can get a login page by sending, e.g., a request to [this url](http://localhost:8080/default/authorize?client_id=foo&response_type=code&redirect_uri=http://localhost:3000&scope=openid).

--- a/compose.yml
+++ b/compose.yml
@@ -3,27 +3,7 @@ services:
     image: ghcr.io/navikt/mock-oauth2-server:2.1.10
     ports:
       - 127.0.0.1:8080:8080
+    volumes:
+      - ./config:/app/conf
     environment:
-      JSON_CONFIG:
-        '{
-          "tokenCallbacks": [
-              {   
-                  "issuerId": "meshwith",
-                  "tokenExpiry": 120,
-                  "requestMappings": [
-                      {   
-                          "requestParam": "grant_type",
-                          "match": "authorization_code",
-                          "claims": {
-                              "scope": "${scope}",
-                              "aud": [
-                                  "testCode" ]
-                          }   
-                      }   
-                  ]   
-              }  
-          ]   
-      }'
- 
-        
-        
+      JSON_CONFIG_PATH: /app/conf/config.json

--- a/compose.yml
+++ b/compose.yml
@@ -1,0 +1,29 @@
+services:
+  app:
+    image: ghcr.io/navikt/mock-oauth2-server:2.1.10
+    ports:
+      - 127.0.0.1:8080:8080
+    environment:
+      JSON_CONFIG:
+        '{
+          "tokenCallbacks": [
+              {   
+                  "issuerId": "meshwith",
+                  "tokenExpiry": 120,
+                  "requestMappings": [
+                      {   
+                          "requestParam": "grant_type",
+                          "match": "authorization_code",
+                          "claims": {
+                              "aud": [
+                                  "testCode" ],
+                              "scopes": "custom scopes"
+                          }   
+                      }   
+                  ]   
+              }  
+          ]   
+      }'
+ 
+        
+        

--- a/compose.yml
+++ b/compose.yml
@@ -15,9 +15,9 @@ services:
                           "requestParam": "grant_type",
                           "match": "authorization_code",
                           "claims": {
+                              "scope": "${scope}",
                               "aud": [
-                                  "testCode" ],
-                              "scopes": "custom scopes"
+                                  "testCode" ]
                           }   
                       }   
                   ]   

--- a/config/config.json
+++ b/config/config.json
@@ -8,9 +8,10 @@
                     "requestParam": "grant_type",
                     "match": "authorization_code",
                     "claims": {
+                        "sub": "${client_id}",
                         "aud": [
                             "testCode" ],
-                        "scope": "${scope}"
+                        "scopes": "${scopes}"
                     }   
                 }   
             ]   

--- a/config/config.json
+++ b/config/config.json
@@ -1,0 +1,19 @@
+{
+    "tokenCallbacks": [
+        {   
+            "issuerId": "meshwith",
+            "tokenExpiry": 120,
+            "requestMappings": [
+                {
+                    "requestParam": "grant_type",
+                    "match": "authorization_code",
+                    "claims": {
+                        "aud": [
+                            "testCode" ],
+                        "scope": "${scope}"
+                    }   
+                }   
+            ]   
+        }  
+    ]   
+}

--- a/example_auth.py
+++ b/example_auth.py
@@ -67,6 +67,8 @@ def get_authorization_code():
     }
 
     response = requests.post(authorization_url, params=params, data=data)
+    print(response.request.url)
+    print(response.request.body)
 
     if response.status_code != 200:
         raise Exception("{} when trying to authorize: {}".format(response.status_code, response.content))
@@ -88,11 +90,15 @@ def get_access_token(auth_code):
     server_thread = threading.Thread(target=AuthHandler.start_server, daemon=True)
     server_thread.start()
 
+    # For some odd reason, our mock server refuses to recognize 'scope' (singular)
+    # So we have to make sure that we have 'scopes' (plural) in our request
+    # This applies ONLY to access token - the server will refuse a 'scopes' (plural)
+    # request for the authorization code
     data = {
         'grant_type': 'authorization_code',
         'client_id': client_id,
         'client_secret': client_secret,
-        'scope': scopes,
+        'scopes': scopes,
         'code': auth_code,
     }
     headers = {'Content-Type': 'application/x-www-form-urlencoded'}
@@ -100,7 +106,6 @@ def get_access_token(auth_code):
     response = requests.post(token_url, data=data, headers=headers)
     print(response.request.url)
     print(response.request.body)
-    print(response.request.headers)
 
     if response.ok:
         token_data = response.json()

--- a/example_auth.py
+++ b/example_auth.py
@@ -6,18 +6,18 @@ import jwt
 from jwt import PyJWKClient
 
 # Configuration
-client_id = 'your_client_id'
+client_id = "your_client_id_part_two"
 client_secret = 'your_client_secret'
 # redirect_uri = 'http://localhost:8080/callback'
 scopes = 'openid profile email'
-authorization_url = "http://localhost:8080/default/authorize"
-well_known_url = "http://localhost:8080/default/jwks"
-token_url = "http://localhost:8080/default/token"
-userinfo_url = "http://localhost:8080/default/userinfo"
+authorization_url = "http://localhost:8080/meshwith/authorize"
+well_known_url = "http://localhost:8080/meshwith/jwks"
+token_url = "http://localhost:8080/meshwith/token"
+userinfo_url = "http://localhost:8080/meshwith/userinfo"
 username = "test@test.com"
 password = "test"
-audience = client_id 
-claims = {}  # Additional claims to request.
+audience = 'testCode'
+claims = {"aud": audience}  # Additional claims to request.
 local_capture_port = 3001
 
 # Local Server to Capture Authorization Code
@@ -57,12 +57,11 @@ def get_authorization_code():
         'client_id': client_id,
         'redirect_uri': 'http://localhost:{}/callback'.format(local_capture_port),
         'response_type': 'code',
-        'scope': scopes
+        'scope': scopes,
     }
 
     data = {
         'username': username,
-        'claims': claims
     }
 
     response = requests.post(authorization_url, params=params, data=data)
@@ -92,9 +91,10 @@ def get_access_token(auth_code):
         'client_id': client_id,
         'client_secret': client_secret,
         'code': auth_code,
+        'claims': claims
     }
     headers = {'Content-Type': 'application/x-www-form-urlencoded'}
-    
+
     response = requests.post(token_url, data=data, headers=headers)
 
     if response.ok:
@@ -138,3 +138,4 @@ if __name__ == "__main__":
             fetch_user_info(token)
     except Exception as e:
         print("Error:", e)
+

--- a/example_auth.py
+++ b/example_auth.py
@@ -1,4 +1,5 @@
 import requests
+import os
 from urllib.parse import urlparse, parse_qs
 from http.server import BaseHTTPRequestHandler, HTTPServer
 import threading
@@ -47,6 +48,7 @@ class AuthHandler(BaseHTTPRequestHandler):
 
 # Step 1: Capture Authorization Code
 def get_authorization_code():
+    
     # Start the local server in a separate thread to capture the code
     server_thread = threading.Thread(target=AuthHandler.start_server, daemon=True)
     server_thread.start()
@@ -90,11 +92,15 @@ def get_access_token(auth_code):
         'grant_type': 'authorization_code',
         'client_id': client_id,
         'client_secret': client_secret,
+        'scope': scopes,
         'code': auth_code,
     }
     headers = {'Content-Type': 'application/x-www-form-urlencoded'}
 
     response = requests.post(token_url, data=data, headers=headers)
+    print(response.request.url)
+    print(response.request.body)
+    print(response.request.headers)
 
     if response.ok:
         token_data = response.json()

--- a/example_auth.py
+++ b/example_auth.py
@@ -16,8 +16,7 @@ token_url = "http://localhost:8080/meshwith/token"
 userinfo_url = "http://localhost:8080/meshwith/userinfo"
 username = "test@test.com"
 password = "test"
-audience = 'testCode'
-claims = {"aud": audience}  # Additional claims to request.
+audience = 'testCode'  # Matches compose.yml
 local_capture_port = 3001
 
 # Local Server to Capture Authorization Code
@@ -58,6 +57,7 @@ def get_authorization_code():
         'redirect_uri': 'http://localhost:{}/callback'.format(local_capture_port),
         'response_type': 'code',
         'scope': scopes,
+        'audience': audience
     }
 
     data = {
@@ -91,7 +91,6 @@ def get_access_token(auth_code):
         'client_id': client_id,
         'client_secret': client_secret,
         'code': auth_code,
-        'claims': claims
     }
     headers = {'Content-Type': 'application/x-www-form-urlencoded'}
 


### PR DESCRIPTION
The config defines an audience and scopes for the `meshwith` directory. With this config file, we now must use make requests to the `meshwith` path or the request will fail.

For the time being, the config JSON is stored in `compose.yml` because I couldn't figure out how to add a relative path to  `compose.yml`.

The program will fail if the `aud` claim does not match the `aud` claim defined in `compose.yml`. The config file seemingly ignores the scopes we give it (ie doesn't force it to match) despite the server requiring us to provide scopes in our requests.

Should resolve #3 and maybe #1. I'm not entirely sure if the behavior described above is acceptable for our use cases.